### PR TITLE
Bug/ 8933 & 9308: update reader info on homepage

### DIFF
--- a/ClearentIdtechIOSFramework.xcodeproj/project.pbxproj
+++ b/ClearentIdtechIOSFramework.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		0169C2E527FF1A4600B8B4DB /* ClearentMarginableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0169C2E127FF1A4600B8B4DB /* ClearentMarginableView.swift */; };
 		0169C2E627FF1A4600B8B4DB /* ClearentAdaptiveStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0169C2E227FF1A4600B8B4DB /* ClearentAdaptiveStackView.swift */; };
 		0169C2E727FF1A4600B8B4DB /* ClearentXibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0169C2E327FF1A4600B8B4DB /* ClearentXibView.swift */; };
+		01D1ED6F280FFA680005FC71 /* ReaderInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D1ED6E280FFA680005FC71 /* ReaderInfo.swift */; };
 		01F6D5792805744E00310E01 /* PaymentFeedbackComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6D5782805744E00310E01 /* PaymentFeedbackComponent.swift */; };
 		01F6D57B280580B200310E01 /* ClearentStringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6D57A280580B200310E01 /* ClearentStringExtension.swift */; };
 		1937010A27F1CAB400BF48E5 /* ClearentPaymentProcessingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937010827F1CAB400BF48E5 /* ClearentPaymentProcessingViewController.swift */; };
@@ -184,6 +185,7 @@
 		0169C2E127FF1A4600B8B4DB /* ClearentMarginableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearentMarginableView.swift; sourceTree = "<group>"; };
 		0169C2E227FF1A4600B8B4DB /* ClearentAdaptiveStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearentAdaptiveStackView.swift; sourceTree = "<group>"; };
 		0169C2E327FF1A4600B8B4DB /* ClearentXibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearentXibView.swift; sourceTree = "<group>"; };
+		01D1ED6E280FFA680005FC71 /* ReaderInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderInfo.swift; sourceTree = "<group>"; };
 		01F6D5782805744E00310E01 /* PaymentFeedbackComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentFeedbackComponent.swift; sourceTree = "<group>"; };
 		01F6D57A280580B200310E01 /* ClearentStringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearentStringExtension.swift; sourceTree = "<group>"; };
 		1937010827F1CAB400BF48E5 /* ClearentPaymentProcessingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearentPaymentProcessingViewController.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 		BAC4E3C027FC3DC9001B5E6D /* PaymentFlowDataSource */ = {
 			isa = PBXGroup;
 			children = (
+				01D1ED6E280FFA680005FC71 /* ReaderInfo.swift */,
 				BAC4E3C127FC3E44001B5E6D /* Identifiers.swift */,
 				BAC4E3C327FC3E88001B5E6D /* FlowDataProvider.swift */,
 				01F6D5782805744E00310E01 /* PaymentFeedbackComponent.swift */,
@@ -942,6 +945,7 @@
 				BA40A34C27F1B38C0041CCF7 /* SDKWrapper.swift in Sources */,
 				0169C2E527FF1A4600B8B4DB /* ClearentMarginableView.swift in Sources */,
 				01F6D57B280580B200310E01 /* ClearentStringExtension.swift in Sources */,
+				01D1ED6F280FFA680005FC71 /* ReaderInfo.swift in Sources */,
 				E75891FC225522AB00288032 /* ClearentLogging.m in Sources */,
 				010394962803462F000A7A94 /* UIStackViewExtension.swift in Sources */,
 				E75891F7225522AB00288032 /* ClearentLoggingRequest.m in Sources */,

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingPresenter.swift
@@ -9,14 +9,13 @@
 import UIKit
 
 public protocol ClearentPaymentProcessingView: AnyObject {
-    func updateInfoLabel(message: String)
-    func updatePairingButton(shouldBeHidden: Bool)
     func updateContent(with component: PaymentFeedbackComponentProtocol)
 }
 
 public protocol PaymentProcessingProtocol {
     func startBluetoothDevicePairing()
     func pairAgainBluetoothDevice()
+    var dismissAction: (() -> Void)? { get set }
 }
 
 public class ClearentPaymentProcessingPresenter {
@@ -24,6 +23,7 @@ public class ClearentPaymentProcessingPresenter {
     private var amount: Double
     private let sdkWrapper: SDKWrapper
     private var sdkFeedbackProvider: FlowDataProvider
+    public var dismissAction: (() -> Void)?
 
     // MARK: Init
 
@@ -39,14 +39,9 @@ public class ClearentPaymentProcessingPresenter {
 extension ClearentPaymentProcessingPresenter: PaymentProcessingProtocol {
     public func startBluetoothDevicePairing() {
         sdkFeedbackProvider.delegate = self
-        guard let paymentProcessingView = paymentProcessingView else { return }
-        paymentProcessingView.updatePairingButton(shouldBeHidden: true)
-        
         if sdkWrapper.isReaderConnected() {
             sdkWrapper.startTransactionWithAmount(amount: String(amount))
         } else {
-            paymentProcessingView.updateInfoLabel(message: "SEARCHING FOR READER...")
-            
             sdkWrapper.startPairing()
         }
     }
@@ -58,14 +53,10 @@ extension ClearentPaymentProcessingPresenter: PaymentProcessingProtocol {
 
 extension ClearentPaymentProcessingPresenter: FlowDataProtocol {
     public func deviceDidDisconnect() {
-        guard let paymentProcessingView = paymentProcessingView else { return }
-        paymentProcessingView.updateInfoLabel(message: "Oops, Device Disconnected")
-        paymentProcessingView.updatePairingButton(shouldBeHidden: false)
+        // TODO
     }
     
     func didFinishedPairing() {
-        guard let paymentProcessingView = paymentProcessingView else { return }
-        paymentProcessingView.updateInfoLabel(message: "Device Successfully Paired")
         sdkWrapper.startTransactionWithAmount(amount: String(amount))
     }
 

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingPresenter.swift
@@ -45,7 +45,7 @@ extension ClearentPaymentProcessingPresenter: PaymentProcessingProtocol {
             sdkWrapper.startPairing()
         }
     }
-    
+
     public func pairAgainBluetoothDevice() {
         sdkWrapper.startPairing()
     }
@@ -53,9 +53,9 @@ extension ClearentPaymentProcessingPresenter: PaymentProcessingProtocol {
 
 extension ClearentPaymentProcessingPresenter: FlowDataProtocol {
     public func deviceDidDisconnect() {
-        // TODO
+        // TODO: implement method
     }
-    
+
     func didFinishedPairing() {
         sdkWrapper.startTransactionWithAmount(amount: String(amount))
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
@@ -9,17 +9,19 @@
 import UIKit
 
 public class ClearentPaymentProcessingViewController: UIViewController {
+    
+    // MARK: - Properties
+    
     @IBOutlet var stackView: ClearentAdaptiveStackView!
-
     public var presenter: PaymentProcessingProtocol?
-    private var initialTouchPoint = CGPoint.zero
-    private enum ModalLayout {
+    private struct Layout {
         static let cornerRadius = 15.0
         static let margin = 16.0
         static let backgroundColor = ClearentConstants.Color.backgroundSecondary01
     }
 
-    // MARK: Init
+
+    // MARK: - Init
 
     public init() {
         super.init(nibName: String(describing: ClearentPaymentProcessingViewController.self), bundle: ClearentConstants.bundle)
@@ -30,7 +32,7 @@ public class ClearentPaymentProcessingViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: Lifecycle
+    // MARK: - Lifecycle
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -38,7 +40,7 @@ public class ClearentPaymentProcessingViewController: UIViewController {
         presenter?.startBluetoothDevicePairing()
     }
     
-    // MARK: Private
+    // MARK: - Private
     
     private func dismissViewController() {
         dismiss(animated: true, completion: nil)
@@ -49,11 +51,11 @@ public class ClearentPaymentProcessingViewController: UIViewController {
     private func setupStyle() {
         view.backgroundColor = .clear
         view.isOpaque = false
-        stackView.addRoundedCorners(backgroundColor: ModalLayout.backgroundColor, radius: ModalLayout.cornerRadius, margin: ModalLayout.margin)
+        stackView.addRoundedCorners(backgroundColor: Layout.backgroundColor, radius: Layout.cornerRadius, margin: Layout.margin)
     }
 }
 
-// MARK: ClearentPaymentProcessingView
+// MARK: - ClearentPaymentProcessingView
 
 extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView {
     public func updateContent(with component: PaymentFeedbackComponentProtocol) {

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
@@ -19,6 +19,7 @@ public class ClearentPaymentProcessingViewController: UIViewController {
         static let margin = 16.0
         static let backgroundColor = ClearentConstants.Color.backgroundSecondary01
     }
+    private var initialTouchPoint = CGPoint.zero
 
 
     // MARK: - Init
@@ -38,6 +39,7 @@ public class ClearentPaymentProcessingViewController: UIViewController {
         super.viewDidLoad()
         setupStyle()
         presenter?.startBluetoothDevicePairing()
+        view.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDismiss)))
     }
     
     // MARK: - Private
@@ -99,6 +101,37 @@ extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView
                 self?.dismissViewController()
             }
             stackView.addArrangedSubview(button)
+        }
+    }
+}
+
+// MARK: Dismiss
+
+extension ClearentPaymentProcessingViewController {
+    enum Constants {
+        static let dismissTreshold = 200.0
+        static let dismissAnimationDuration = 0.3
+    }
+
+    @objc func handleDismiss(sender: UIPanGestureRecognizer) {
+        let touchPoint = sender.location(in: view?.window)
+        switch sender.state {
+        case .began:
+            initialTouchPoint = touchPoint
+        case .changed:
+            if touchPoint.y > initialTouchPoint.y {
+                view.frame.origin.y = touchPoint.y - initialTouchPoint.y
+            }
+        case .ended, .cancelled:
+            if touchPoint.y - initialTouchPoint.y > Constants.dismissTreshold {
+                dismissViewController()
+            } else {
+                UIView.animate(withDuration: Constants.dismissAnimationDuration, animations: {
+                    self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: self.view.frame.size.height)
+                })
+            }
+        default:
+            break
         }
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
@@ -50,39 +50,6 @@ public class ClearentPaymentProcessingViewController: UIViewController {
         view.backgroundColor = .clear
         view.isOpaque = false
         stackView.addRoundedCorners(backgroundColor: ModalLayout.backgroundColor, radius: ModalLayout.cornerRadius, margin: ModalLayout.margin)
-        view.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDismiss)))
-    }
-}
-
-
-// MARK: Swipe down
-
-extension ClearentPaymentProcessingViewController {
-    enum Constants {
-        static let dismissTreshold = 200.0
-        static let dismissAnimationDuration = 0.3
-    }
-
-    @objc func handleDismiss(sender: UIPanGestureRecognizer) {
-        let touchPoint = sender.location(in: view?.window)
-        switch sender.state {
-        case .began:
-            initialTouchPoint = touchPoint
-        case .changed:
-            if touchPoint.y > initialTouchPoint.y {
-                view.frame.origin.y = touchPoint.y - initialTouchPoint.y
-            }
-        case .ended, .cancelled:
-            if touchPoint.y - initialTouchPoint.y > Constants.dismissTreshold {
-                dismissViewController()
-            } else {
-                UIView.animate(withDuration: Constants.dismissAnimationDuration, animations: {
-                    self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: self.view.frame.size.height)
-                })
-            }
-        default:
-            break
-        }
     }
 }
 

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
@@ -9,8 +9,8 @@
 import UIKit
 
 public class ClearentPaymentProcessingViewController: UIViewController {
-    @IBOutlet weak var stackView: ClearentAdaptiveStackView!
-    
+    @IBOutlet var stackView: ClearentAdaptiveStackView!
+
     public var presenter: PaymentProcessingProtocol?
     private var initialTouchPoint = CGPoint.zero
     private enum ModalLayout {
@@ -41,7 +41,7 @@ public class ClearentPaymentProcessingViewController: UIViewController {
     // MARK: Private
     
     private func dismissViewController() {
-        self.dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: nil)
         SDKWrapper.shared.cancelTransaction()
         presenter?.dismissAction?()
     }
@@ -62,7 +62,7 @@ extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView
         createMainInfoView(with: component)
         createButton(with: component)
     }
-    
+
     private func createStatusHeader(with component: PaymentFeedbackComponentProtocol) {
         let readerStatusHeader = ClearentReaderStatusHeaderView()
         readerStatusHeader.setup(readerName: component.readerName,
@@ -72,7 +72,7 @@ extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView
                                  batteryStatusTitle: component.batteryStatus.title)
         stackView.addArrangedSubview(readerStatusHeader)
     }
-    
+
     private func createMainInfoView(with component: PaymentFeedbackComponentProtocol) {
         if let description = component.mainDescription {
             if let iconName = component.iconName, let title = component.mainTitle {
@@ -88,7 +88,7 @@ extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView
             }
         }
     }
-    
+
     private func createButton(with component: PaymentFeedbackComponentProtocol) {
         if let userAction = component.userAction {
             let button = ClearentPrimaryButton()

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentPaymentProcessingViewController.swift
@@ -9,10 +9,11 @@
 import UIKit
 
 public class ClearentPaymentProcessingViewController: UIViewController {
-    public var presenter: PaymentProcessingProtocol?
     @IBOutlet weak var stackView: ClearentAdaptiveStackView!
     
-    enum ModalLayout {
+    public var presenter: PaymentProcessingProtocol?
+    private var initialTouchPoint = CGPoint.zero
+    private enum ModalLayout {
         static let cornerRadius = 15.0
         static let margin = 16.0
         static let backgroundColor = ClearentConstants.Color.backgroundSecondary01
@@ -33,42 +34,79 @@ public class ClearentPaymentProcessingViewController: UIViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-        customizeModalView()
+        setupStyle()
         presenter?.startBluetoothDevicePairing()
     }
-
+    
     // MARK: Private
-
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    
+    private func dismissViewController() {
+        self.dismiss(animated: true, completion: nil)
+        SDKWrapper.shared.cancelTransaction()
+        presenter?.dismissAction?()
     }
 
-    private func customizeModalView() {
+    private func setupStyle() {
         view.backgroundColor = .clear
         view.isOpaque = false
         stackView.addRoundedCorners(backgroundColor: ModalLayout.backgroundColor, radius: ModalLayout.cornerRadius, margin: ModalLayout.margin)
+        view.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDismiss)))
     }
 }
 
+
+// MARK: Swipe down
+
+extension ClearentPaymentProcessingViewController {
+    enum Constants {
+        static let dismissTreshold = 200.0
+        static let dismissAnimationDuration = 0.3
+    }
+
+    @objc func handleDismiss(sender: UIPanGestureRecognizer) {
+        let touchPoint = sender.location(in: view?.window)
+        switch sender.state {
+        case .began:
+            initialTouchPoint = touchPoint
+        case .changed:
+            if touchPoint.y > initialTouchPoint.y {
+                view.frame.origin.y = touchPoint.y - initialTouchPoint.y
+            }
+        case .ended, .cancelled:
+            if touchPoint.y - initialTouchPoint.y > Constants.dismissTreshold {
+                dismissViewController()
+            } else {
+                UIView.animate(withDuration: Constants.dismissAnimationDuration, animations: {
+                    self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: self.view.frame.size.height)
+                })
+            }
+        default:
+            break
+        }
+    }
+}
+
+// MARK: ClearentPaymentProcessingView
+
 extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView {
-    public func updateInfoLabel(message: String) {
-        //paymentProcessingLabel.text = message
-    }
-
-    public func updatePairingButton(shouldBeHidden: Bool) {
-        //pairBluetoothDeviceButton.isHidden = shouldBeHidden
-    }
-
     public func updateContent(with component: PaymentFeedbackComponentProtocol) {
         stackView.removeAllArrangedSubviews()
-
-        // ReaderStatusHeaderView
+        createStatusHeader(with: component)
+        createMainInfoView(with: component)
+        createButton(with: component)
+    }
+    
+    private func createStatusHeader(with component: PaymentFeedbackComponentProtocol) {
         let readerStatusHeader = ClearentReaderStatusHeaderView()
         readerStatusHeader.setup(readerName: component.readerName,
-                                 connectivityStatusImageName: component.signalStatus.iconName, connectivityStatus: component.signalStatus.title,
-                                 readerBatteryStatusImageName: component.batteryStatus.iconName, readerBatteryStatus: component.batteryStatus.title)
+                                 signalStatusIconName: component.signalStatus.iconName,
+                                 signalStatusTitle: component.signalStatus.title,
+                                 batteryStatusIconName: component.batteryStatus.iconName,
+                                 batteryStatusTitle: component.batteryStatus.title)
         stackView.addArrangedSubview(readerStatusHeader)
-
+    }
+    
+    private func createMainInfoView(with component: PaymentFeedbackComponentProtocol) {
         if let description = component.mainDescription {
             if let iconName = component.iconName, let title = component.mainTitle {
                 // ReaderFeedbackView
@@ -82,14 +120,14 @@ extension ClearentPaymentProcessingViewController: ClearentPaymentProcessingView
                 stackView.addArrangedSubview(actionView)
             }
         }
-
-        // PrimaryButton
+    }
+    
+    private func createButton(with component: PaymentFeedbackComponentProtocol) {
         if let userAction = component.userAction {
             let button = ClearentPrimaryButton()
             button.title = userAction
             button.action = { [weak self] in
-                self?.dismiss(animated: true)
-                SDKWrapper.shared.cancelTransaction()
+                self?.dismissViewController()
             }
             stackView.addArrangedSubview(button)
         }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.swift
@@ -8,14 +8,14 @@
 
 import UIKit
 
-class ClearentReaderStatusHeaderView: ClearentMarginableView {
+public class ClearentReaderStatusHeaderView: ClearentMarginableView {
     
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var readerNameLabel: UILabel!
     @IBOutlet weak var readerConnectivityStatusView: ClearentReaderConnectivityStatusView!
     @IBOutlet weak var readerBatteryStatusView: ClearentReaderConnectivityStatusView!
     
-    override var margins: [BottomMargin] {
+    public override var margins: [BottomMargin] {
         [
             RelativeBottomMargin(constant: 50.0, relatedViewType: ClearentUserActionView.self),
             RelativeBottomMargin(constant: 30.0, relatedViewType: ClearentReaderFeedbackView.self)
@@ -25,16 +25,17 @@ class ClearentReaderStatusHeaderView: ClearentMarginableView {
     // MARK: Public
     
     public func setup(readerName: String,
-                      connectivityStatusImageName: String,
-                      connectivityStatus: String,
-                      readerBatteryStatusImageName: String?,
-                      readerBatteryStatus: String?) {
+                      signalStatusIconName: String,
+                      signalStatusTitle: String,
+                      batteryStatusIconName: String?,
+                      batteryStatusTitle: String?) {
         readerNameLabel.text = readerName
-        readerConnectivityStatusView.setup(imageName: connectivityStatusImageName, status: connectivityStatus)
-        guard let batteryImage = readerBatteryStatusImageName, let batteryStatus = readerBatteryStatus else {
-            readerBatteryStatusView.isHidden = true
+        readerConnectivityStatusView.setup(imageName: signalStatusIconName, status: signalStatusTitle)
+        if let batteryImage = batteryStatusIconName, let batteryStatus = batteryStatusTitle {
+            readerBatteryStatusView.isHidden = false
+            readerBatteryStatusView.setup(imageName: batteryImage, status: batteryStatus)
             return
         }
-        readerBatteryStatusView.setup(imageName: batteryImage, status: batteryStatus)
+        readerBatteryStatusView.isHidden = true
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.xib
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.xib
@@ -10,8 +10,8 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <array key="SF-Pro-Text-Medium.otf">
-            <string>SFProText-Medium</string>
+        <array key="SF-Pro-Text-Regular.otf">
+            <string>SFProText-Regular</string>
         </array>
     </customFonts>
     <objects>
@@ -35,7 +35,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="Ygf-U4-Z2A"/>
                     </constraints>
-                    <fontDescription key="fontDescription" name="SFProText-Medium" family="SF Pro Text" pointSize="14"/>
+                    <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="14"/>
                     <color key="textColor" red="0.10588235294117647" green="0.094117647058823528" blue="0.12156862745098039" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                     <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.xib
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.xib
@@ -10,8 +10,8 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <array key="SF-Pro-Text-Regular.otf">
-            <string>SFProText-Regular</string>
+        <array key="SF-Pro-Text-Medium.otf">
+            <string>SFProText-Medium</string>
         </array>
     </customFonts>
     <objects>
@@ -35,7 +35,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="20" id="Ygf-U4-Z2A"/>
                     </constraints>
-                    <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="14"/>
+                    <fontDescription key="fontDescription" name="SFProText-Medium" family="SF Pro Text" pointSize="14"/>
                     <color key="textColor" red="0.10588235294117647" green="0.094117647058823528" blue="0.12156862745098039" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                     <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentAdaptiveStackView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentAdaptiveStackView.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 /// A custom UIStackView  that supports subviews with different margins between them.
-class ClearentAdaptiveStackView: UIStackView {
+public class ClearentAdaptiveStackView: UIStackView {
     // MARK: - Lifecycle
 
-    override func layoutSubviews() {
+    public override func layoutSubviews() {
         super.layoutSubviews()
         handleSubviewsMargins()
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentMarginable.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentMarginable.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 // Helper class used to create space between two views
-protocol ClearentMarginable {
+public protocol ClearentMarginable {
     var viewType: UIView.Type { get }
     var margins: [BottomMargin] { get }
     func handleBottomMargin(to neighbor: ClearentMarginable?)
@@ -16,7 +16,7 @@ protocol ClearentMarginable {
 }
 
 extension ClearentMarginable {
-    func handleBottomMargin(to neighbor: ClearentMarginable?) {
+    public func handleBottomMargin(to neighbor: ClearentMarginable?) {
         for margin in margins {
             if let relatedViewMargin = margin as? RelativeBottomMargin {
                 if neighbor != nil, neighbor?.viewType == relatedViewMargin.relatedViewType {
@@ -29,7 +29,7 @@ extension ClearentMarginable {
     }
 }
 
-class BottomMargin {
+public class BottomMargin {
     var constant: CGFloat
     
     init(contant: CGFloat) {

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentMarginableView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentMarginableView.swift
@@ -8,14 +8,14 @@
 import UIKit
 
 /// A ClearentXibView subclass that adds custom bottom padding to the view
-class ClearentMarginableView: ClearentXibView, ClearentMarginable {
+public class ClearentMarginableView: ClearentXibView, ClearentMarginable {
 
     @IBOutlet var bottomLayoutConstraint: NSLayoutConstraint?
 
-    var viewType: UIView.Type { type(of: self) }
-    var margins: [BottomMargin] { [] }
+    public var viewType: UIView.Type { type(of: self) }
+    public var margins: [BottomMargin] { [] }
 
-    func setBottomMargin(margin: BottomMargin) {
+    public func setBottomMargin(margin: BottomMargin) {
         bottomLayoutConstraint?.constant = margin.constant
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentXibView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/AdaptiveStackView/ClearentXibView.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 /// A custom UIView  that contains all the necessary methods for loading a view from nib. Could be used as a base class for UI components in order to avoid boilerplate code.
-class ClearentXibView: UIView {
+public class ClearentXibView: UIView {
     // MARK: - Lifecycle
 
-    override func awakeFromNib() {
+    public override func awakeFromNib() {
         super.awakeFromNib()
         configure()
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
@@ -20,42 +20,17 @@ class FlowFeedback {
     }
 }
 
-public struct ReaderInfo {
-    var readerName : String
-    var batterylevel : Int?
-    var signalLevel : Int?
-    var isConnected : Bool
-    var udid: UUID?
-    
-    init(name: String?, batterylevel: Int, signalLevel:Int, connected: Bool) {
-        self.readerName = "xsdk_unknown_reader_name".localized
-        if let readerName = name {
-            self.readerName = readerName
-        }
-        self.batterylevel = batterylevel
-        self.signalLevel = signalLevel
-        self.isConnected = connected
-    }
-}
-
 class FlowDataFactory {
     
     class func component(with flow: ProcessType, type: FlowFeedbackType, readerInfo: ReaderInfo?, payload:[FlowDataKeys:Any])-> FlowFeedback {
         
         if let readerInfo = readerInfo {
-            let readerInfoDict = createDictionaryWithDeviceInfo(readerInfo: readerInfo)
-            let dataDict = payload.merging(readerInfoDict) { (current, _) in current }
+            var dataDict = payload
+            dataDict[.readerInfo] = readerInfo
             return FlowFeedback(flow: flow, type: type, items: dataDict)
         }
       
         return FlowFeedback(flow: flow, type: type, items: payload)
-    }
-        
-    class func createDictionaryWithDeviceInfo(readerInfo:ReaderInfo) -> [FlowDataKeys:Any] {
-        return [.readerConnected : readerInfo.isConnected,
-                .readerName : readerInfo.readerName,
-                .readerBatteryLevel : readerInfo.batterylevel ?? 0,
-                .readerSignalLevel:readerInfo.signalLevel ?? 0]
     }
 }
 

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/Identifiers.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/Identifiers.swift
@@ -13,7 +13,7 @@ enum SignalLevel : Int {
 }
 
 enum FlowDataKeys {
-    case readerConnected, readerBatteryLevel, readerSignalLevel, readerName, graphicType, title, description, userAction
+    case readerInfo, graphicType, title, description, userAction
 }
 
 enum FlowFeedbackType {

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/PaymentFeedbackComponent.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/PaymentFeedbackComponent.swift
@@ -30,45 +30,20 @@ struct PaymentFeedbackComponent: PaymentFeedbackComponentProtocol {
     }
 
     var readerName: String {
-        guard let readerName = feedbackItems[.readerName] as? String else {
+        guard let readerInfo = feedbackItems[.readerInfo] as? ReaderInfo else {
             return "xsdk_unknown_reader_name".localized
         }
-        return readerName
+        return readerInfo.readerName
     }
 
     var batteryStatus: (iconName: String?, title: String?) {
-        // if reader is not connected, battery should not be shown
-        guard let batteryLevel = feedbackItems[.readerBatteryLevel] as? Int,
-              let connected = feedbackItems[.readerConnected] as? Bool, connected else {
-                  return (nil, nil)
-              }
-        var iconName = ClearentConstants.IconName.batteryLow
-        if batteryLevel > 95 { iconName = ClearentConstants.IconName.batteryFull }
-        else if batteryLevel > 75 { iconName = ClearentConstants.IconName.batteryHigh }
-        else if batteryLevel > 50 { iconName = ClearentConstants.IconName.batteryMediumHigh }
-        else if batteryLevel > 25 { iconName = ClearentConstants.IconName.batteryMedium }
-        else if batteryLevel > 5 { iconName = ClearentConstants.IconName.batteryMediumLow }
-        return (iconName, "\(String(batteryLevel))%")
+        guard let readerInfo = feedbackItems[.readerInfo] as? ReaderInfo else { return (nil, nil) }
+        return readerInfo.batteryStatus
     }
 
     var signalStatus: (iconName: String, title: String) {
-        guard let connected = feedbackItems[.readerConnected] as? Bool, connected, let signalLevel = feedbackItems[.readerSignalLevel] as? Int else {
-            return (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized)
-        }
-        
-        var icon = ClearentConstants.IconName.signalIdle
-        switch signalLevel {
-            case 0 :
-                icon =  ClearentConstants.IconName.goodSignal
-            case 1 :
-                icon =  ClearentConstants.IconName.mediumSignal
-            case 2 :
-                icon =  ClearentConstants.IconName.weakSignal
-            default:
-                icon =  ClearentConstants.IconName.signalIdle
-        }
-        
-        return (iconName: icon, title: "xsdk_reader_signal_connected".localized)
+        guard let readerInfo = feedbackItems[.readerInfo] as? ReaderInfo else { return  (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized) }
+        return readerInfo.signalStatus
     }
 
     var iconName: String? {

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/PaymentFeedbackComponent.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/PaymentFeedbackComponent.swift
@@ -42,7 +42,7 @@ struct PaymentFeedbackComponent: PaymentFeedbackComponentProtocol {
     }
 
     var signalStatus: (iconName: String, title: String) {
-        guard let readerInfo = feedbackItems[.readerInfo] as? ReaderInfo else { return  (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized) }
+        guard let readerInfo = feedbackItems[.readerInfo] as? ReaderInfo else { return (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized) }
         return readerInfo.signalStatus
     }
 

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
@@ -1,0 +1,61 @@
+//
+//  ReaderInfo.swift
+//  ClearentIdtechIOSFramework
+//
+//  Created by Carmen Jurcovan on 19.04.2022.
+//  Copyright © 2022 Clearent, L.L.C. All rights reserved.
+//
+
+public struct ReaderInfo {
+    public var readerName : String
+    var batterylevel : Int?
+    var signalLevel : Int?
+    var isConnected : Bool
+    var udid: UUID?
+    
+    init(name: String?, batterylevel: Int, signalLevel:Int, connected: Bool) {
+        self.readerName = "xsdk_unknown_reader_name".localized
+        if let readerName = name {
+            self.readerName = readerName
+        }
+        self.batterylevel = batterylevel
+        self.signalLevel = signalLevel
+        self.isConnected = connected
+    }
+}
+
+extension ReaderInfo {
+    public var batteryStatus: (iconName: String?, title: String?) {
+        // if reader is not connected, battery should not be shown
+        guard let batteryLevel = batterylevel, isConnected else {
+                  return (nil, nil)
+              }
+        var iconName = ClearentConstants.IconName.batteryLow
+        if batteryLevel > 95 { iconName = ClearentConstants.IconName.batteryFull }
+        else if batteryLevel > 75 { iconName = ClearentConstants.IconName.batteryHigh }
+        else if batteryLevel > 50 { iconName = ClearentConstants.IconName.batteryMediumHigh }
+        else if batteryLevel > 25 { iconName = ClearentConstants.IconName.batteryMedium }
+        else if batteryLevel > 5 { iconName = ClearentConstants.IconName.batteryMediumLow }
+        return (iconName, "\(String(batteryLevel))%")
+    }
+
+    public var signalStatus: (iconName: String, title: String) {
+        guard let signalLevel = signalLevel, isConnected else {
+            return (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized)
+        }
+        
+        var icon = ClearentConstants.IconName.signalIdle
+        switch signalLevel {
+            case 0 :
+                icon =  ClearentConstants.IconName.goodSignal
+            case 1 :
+                icon =  ClearentConstants.IconName.mediumSignal
+            case 2 :
+                icon =  ClearentConstants.IconName.weakSignal
+            default:
+                icon =  ClearentConstants.IconName.signalIdle
+        }
+        
+        return (iconName: icon, title: "xsdk_reader_signal_connected".localized)
+    }
+}

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
@@ -7,29 +7,29 @@
 //
 
 public struct ReaderInfo {
-    public var readerName : String
-    var batterylevel : Int?
-    var signalLevel : Int?
-    var isConnected : Bool
+    public var readerName: String
+    var batterylevel: Int?
+    var signalLevel: Int?
+    var isConnected: Bool
     var udid: UUID?
-    
-    init(name: String?, batterylevel: Int, signalLevel:Int, connected: Bool) {
-        self.readerName = "xsdk_unknown_reader_name".localized
+
+    init(name: String?, batterylevel: Int, signalLevel: Int, connected: Bool) {
+        readerName = "xsdk_unknown_reader_name".localized
         if let readerName = name {
             self.readerName = readerName
         }
         self.batterylevel = batterylevel
         self.signalLevel = signalLevel
-        self.isConnected = connected
+        isConnected = connected
     }
 }
 
-extension ReaderInfo {
-    public var batteryStatus: (iconName: String?, title: String?) {
+public extension ReaderInfo {
+    var batteryStatus: (iconName: String?, title: String?) {
         // if reader is not connected, battery should not be shown
         guard let batteryLevel = batterylevel, isConnected else {
-                  return (nil, nil)
-              }
+            return (nil, nil)
+        }
         var iconName = ClearentConstants.IconName.batteryLow
         if batteryLevel > 95 { iconName = ClearentConstants.IconName.batteryFull }
         else if batteryLevel > 75 { iconName = ClearentConstants.IconName.batteryHigh }
@@ -39,23 +39,23 @@ extension ReaderInfo {
         return (iconName, "\(String(batteryLevel))%")
     }
 
-    public var signalStatus: (iconName: String, title: String) {
+    var signalStatus: (iconName: String, title: String) {
         guard let signalLevel = signalLevel, isConnected else {
             return (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized)
         }
-        
+
         var icon = ClearentConstants.IconName.signalIdle
         switch signalLevel {
-            case 0 :
-                icon =  ClearentConstants.IconName.goodSignal
-            case 1 :
-                icon =  ClearentConstants.IconName.mediumSignal
-            case 2 :
-                icon =  ClearentConstants.IconName.weakSignal
-            default:
-                icon =  ClearentConstants.IconName.signalIdle
+        case 0:
+            icon = ClearentConstants.IconName.goodSignal
+        case 1:
+            icon = ClearentConstants.IconName.mediumSignal
+        case 2:
+            icon = ClearentConstants.IconName.weakSignal
+        default:
+            icon = ClearentConstants.IconName.signalIdle
         }
-        
+
         return (iconName: icon, title: "xsdk_reader_signal_connected".localized)
     }
 }


### PR DESCRIPTION
This PR adds support for displaying the reader's info on the Homepage. More specifically, it changes access modifiers for some of the UI component to `public` to be able accessible from[xplor-pay-mobile](https://github.com/clearent/xplor-pay-mobile) repo.  Also, it extracts `ReaderInfo` class into a separate file and adds some helper methods to it.
Lastly, it adds support for dismissing `ClearentPaymentProcessingViewController` by swiping down.

Related PR: https://github.com/clearent/xplor-pay-mobile/pull/7
