### PR TITLE
Feature/#10167 method for recently paired and available readers

### DIFF
--- a/ClearentIdtechIOSFramework.xcodeproj/project.pbxproj
+++ b/ClearentIdtechIOSFramework.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		BAC4E3C227FC3E44001B5E6D /* Identifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4E3C127FC3E44001B5E6D /* Identifiers.swift */; };
 		BAC4E3C427FC3E88001B5E6D /* FlowDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC4E3C327FC3E88001B5E6D /* FlowDataProvider.swift */; };
 		BAC4E3D127FED72B001B5E6D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BAC4E3D027FED72B001B5E6D /* Localizable.strings */; };
-		BAEAD2D92810041100AA72F6 /* ClearentLoggerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEAD2D82810041100AA72F6 /* ClearentLoggerExtension.swift */; };
+		BAEAD2D92810041100AA72F6 /* ClearentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEAD2D82810041100AA72F6 /* ClearentExtension.swift */; };
 		CC1953B728213ECC00DF3688 /* UserDefaultsPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1953B628213ECC00DF3688 /* UserDefaultsPersistence.swift */; };
 		CC1953B928213F5700DF3688 /* ClearentWrapperDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1953B828213F5700DF3688 /* ClearentWrapperDefaults.swift */; };
 		E702E56523647D6B0032ED8D /* IDTech.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E760460523645A61006CFB78 /* IDTech.framework */; };
@@ -247,7 +247,7 @@
 		BAC4E3C127FC3E44001B5E6D /* Identifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiers.swift; sourceTree = "<group>"; };
 		BAC4E3C327FC3E88001B5E6D /* FlowDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowDataProvider.swift; sourceTree = "<group>"; };
 		BAC4E3D027FED72B001B5E6D /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
-		BAEAD2D82810041100AA72F6 /* ClearentLoggerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearentLoggerExtension.swift; sourceTree = "<group>"; };
+		BAEAD2D82810041100AA72F6 /* ClearentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearentExtension.swift; sourceTree = "<group>"; };
 		CC1953B628213ECC00DF3688 /* UserDefaultsPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsPersistence.swift; sourceTree = "<group>"; };
 		CC1953B828213F5700DF3688 /* ClearentWrapperDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearentWrapperDefaults.swift; sourceTree = "<group>"; };
 		E702E56F2364835B0032ED8D /* ClearentVP3300Config.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClearentVP3300Config.m; sourceTree = "<group>"; };
@@ -485,7 +485,7 @@
 				BA40A34827F1B38C0041CCF7 /* ClearentHttpClient.swift */,
 				BA40A34927F1B38C0041CCF7 /* ClearentWrapper.swift */,
 				BA40A34A27F1B38C0041CCF7 /* HttpClient.swift */,
-				BAEAD2D82810041100AA72F6 /* ClearentLoggerExtension.swift */,
+				BAEAD2D82810041100AA72F6 /* ClearentExtension.swift */,
 			);
 			path = Wrapper;
 			sourceTree = "<group>";
@@ -965,7 +965,7 @@
 				E75A5BEC20DD20580035B911 /* ClearentEmvConfigurator.m in Sources */,
 				4B32C0912432677F00CCF9B9 /* ClearentTransactionToken.m in Sources */,
 				E7CA494520E1753D0090CFFC /* ClearentConfigurator.m in Sources */,
-				BAEAD2D92810041100AA72F6 /* ClearentLoggerExtension.swift in Sources */,
+				BAEAD2D92810041100AA72F6 /* ClearentExtension.swift in Sources */,
 				4BAEA885271C5CD8007F5FCF /* ClearentLumberjack.m in Sources */,
 				19C6EBD1281127E400762CD4 /* Notification.swift in Sources */,
 				E726A0382258B5B400F3E8B7 /* ClearentCache.m in Sources */,

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
@@ -10,6 +10,7 @@ import Foundation
 
 private struct DefaultKeys {
     static let readerFriendlyNameKey = "xsdk_reader_friendly_name_key"
+    static let recentlyPairedReadersKey = "xsdk_recently+paired_readers_key"
 }
 
 class ClearentWrapperDefaults: UserDefaultsPersistence {
@@ -30,6 +31,26 @@ class ClearentWrapperDefaults: UserDefaultsPersistence {
                let encoder = JSONEncoder()
                if let encoded = try? encoder.encode(newValue) {
                    save(encoded, forKey:  DefaultKeys.readerFriendlyNameKey)
+               }
+           }
+       }
+    
+    static var recentlyPairedReaders: [ReaderInfo]? {
+           
+           get {
+               if let savedReaderData = retrieveValue(forKey: DefaultKeys.recentlyPairedReadersKey) as? Data {
+                   let decoder = JSONDecoder()
+                   let loadedReaderInfo = try? decoder.decode([ReaderInfo].self, from: savedReaderData)
+                   return loadedReaderInfo
+               }
+               
+               return nil
+           }
+           
+           set {
+               let encoder = JSONEncoder()
+               if let encoded = try? encoder.encode(newValue) {
+                   save(encoded, forKey:  DefaultKeys.recentlyPairedReadersKey)
                }
            }
        }

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
@@ -251,4 +251,24 @@ extension FlowDataProvider : ClearentWrapperProtocol {
        // commented temporarly so we do not mess up the current flow
        // self.delegate?.didReceiveFlowFeedback(feedback: feedback)
     }
+    
+    func didNotFindRecentlyUsedReaders() {
+        let items = [FlowDataItem(type: .description, object: "xsdk_prepare_for_pairing".localized)]
+        
+        let feedback = FlowDataFactory.component(with: .pairing,
+                                                 type: .searchDevices,
+                                                 readerInfo: nil,
+                                                 payload: items)
+        self.delegate?.didReceiveFlowFeedback(feedback: feedback)
+    }
+    
+    func didFindRecentlyUsedReaders(readers: [ReaderInfo]) {
+        let items = [FlowDataItem(type: .devicesFound, object: readers)]
+        
+        let feedback = FlowDataFactory.component(with: .pairing,
+                                                 type: .searchDevices,
+                                                 readerInfo: nil,
+                                                 payload: items)
+        self.delegate?.didReceiveFlowFeedback(feedback: feedback)
+    }
 }

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
@@ -11,7 +11,7 @@ import CocoaLumberjack
 
 extension ClearentWrapper {
     
-    private func addNewReader(reader:ReaderInfo) {
+    internal func addReaderToRecentlyUsed(reader:ReaderInfo) {
         guard let existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else {
             ClearentWrapperDefaults.recentlyPairedReaders = [reader]
             return
@@ -25,7 +25,7 @@ extension ClearentWrapper {
         }
     }
     
-    private func removeReader(reader: ReaderInfo) {
+    internal func removeReaderFromRecentlyUsed(reader: ReaderInfo) {
         guard var existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
         
         let readersWithSameName = existingReaders.filter { $0.readerName == reader.readerName }
@@ -36,6 +36,20 @@ extension ClearentWrapper {
         }
         
         ClearentWrapperDefaults.recentlyPairedReaders = existingReaders
+    }
+    
+    internal func fetchRecentlyAndAvailableReaders(devices: [ClearentBluetoothDevice]) -> [ReaderInfo] {
+        
+        let availableReaders = devices.compactMap { readerInfo(from: $0)}
+        guard let recentReaders = ClearentWrapperDefaults.recentlyPairedReaders else {return availableReaders}
+       
+        let result = availableReaders.filter {currentReader in recentReaders.contains(where: { $0.readerName == currentReader.readerName }) }
+        return result
+    }
+    
+    internal func readerInfo(from clearentDevice:ClearentBluetoothDevice) -> ReaderInfo {
+        let uuidString: UUID? = UUID(uuidString: clearentDevice.deviceId)
+        return ReaderInfo(name: clearentDevice.friendlyName, batterylevel:nil , signalLevel: nil, connected: clearentDevice.connected, uuid: uuidString)
     }
     
     // MARK - Public Logger related

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
@@ -11,7 +11,31 @@ import CocoaLumberjack
 
 extension ClearentWrapper {
     
-    // MARK - Public
+    private func addNewReader(reader:ReaderInfo) {
+        guard let existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
+        
+        let readersWithSameName = existingReaders.filter { $0.readerName == reader.readerName }
+        if (readersWithSameName.count == 0) {
+            var newReaders : [ReaderInfo] = [reader]
+            newReaders.append(contentsOf: existingReaders)
+            ClearentWrapperDefaults.recentlyPairedReaders = newReaders
+        }
+    }
+    
+    private func removeReader(reader: ReaderInfo) {
+        guard var existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
+        
+        let readersWithSameName = existingReaders.filter { $0.readerName == reader.readerName }
+        if (readersWithSameName.count == 1) {
+            existingReaders.removeAll { current in
+                current.readerName == reader.readerName
+            }
+        }
+        
+        ClearentWrapperDefaults.recentlyPairedReaders = existingReaders
+    }
+    
+    // MARK - Public Logger related
     
     public func retriveLoggFileContents() -> String {
         var logs = ""
@@ -42,7 +66,7 @@ extension ClearentWrapper {
     }
     
     
-    // MARK - Private
+    // MARK - Private Logger related
     
     internal func createLogFile() {
         DDLog.allLoggers.forEach { logger in

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
@@ -9,17 +9,30 @@
 import Foundation
 import CocoaLumberjack
 
+extension ClearentWrapper: BluetoothScannerProtocol {
+    
+    internal func didReceivedSignalStrength(level: SignalLevel) {
+        readerInfo?.signalLevel = level.rawValue
+    }
+    
+    internal func didFinishWithError() {
+        self.delegate?.didFinishPairing()
+    }
+}
+
 extension ClearentWrapper {
     
     internal func addReaderToRecentlyUsed(reader:ReaderInfo) {
+        var newReader = reader
+        newReader.isConnected = false
         guard let existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else {
-            ClearentWrapperDefaults.recentlyPairedReaders = [reader]
+            ClearentWrapperDefaults.recentlyPairedReaders = [newReader]
             return
         }
         
-        let readersWithSameName = existingReaders.filter { $0.readerName == reader.readerName }
+        let readersWithSameName = existingReaders.filter { $0.readerName == newReader.readerName }
         if (readersWithSameName.count == 0) {
-            var newReaders : [ReaderInfo] = [reader]
+            var newReaders : [ReaderInfo] = [newReader]
             newReaders.append(contentsOf: existingReaders)
             ClearentWrapperDefaults.recentlyPairedReaders = newReaders
         }

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
@@ -12,7 +12,10 @@ import CocoaLumberjack
 extension ClearentWrapper {
     
     private func addNewReader(reader:ReaderInfo) {
-        guard let existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
+        guard let existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else {
+            ClearentWrapperDefaults.recentlyPairedReaders = [reader]
+            return
+        }
         
         let readersWithSameName = existingReaders.filter { $0.readerName == reader.readerName }
         if (readersWithSameName.count == 0) {


### PR DESCRIPTION
ClearentWrapper has a new method : **searchRecentlyUsedReaders** that will trigger the process of finding readers around and merging them with the cached readers and will trigger the FLowDataProvider delegates.