### PR TITLE
Feature/#9036: update reader status on pairing flow

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
@@ -11,7 +11,7 @@ import UIKit
 public protocol ClearentProcessingModalView: AnyObject {
     func updateContent(with feedback: FlowFeedback)
     func showLoadingView()
-    func dismissView()
+    func dismissViewController()
 }
 
 public protocol ProcessingModalProtocol {
@@ -42,7 +42,7 @@ public class ClearentProcessingModalPresenter {
     private func dissmissViewWithDelay() {
         let deadlineTime = DispatchTime.now() + .seconds(3)
         DispatchQueue.main.asyncAfter(deadline: deadlineTime) {
-            self.paymentProcessingView?.dismissView()
+            self.paymentProcessingView?.dismissViewController()
         }
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -93,7 +93,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
             return ClearentSubtitleLabel(text: text)
         case .userAction:
             guard let userAction = object as? FlowButtonType else { return nil }
-            return button(userAction: userAction, proccessType: processType)
+            return button(userAction: userAction, processType: processType)
         case .devicesFound:
             guard let readersInfo = object as? [ReaderInfo] else { return nil }
             return readersList(readersInfo: readersInfo)
@@ -128,7 +128,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         return ClearentPairingReadersList(items: items)
     }
 
-    private func button(userAction: FlowButtonType, proccessType: ProcessType) -> ClearentPrimaryButton {
+    private func button(userAction: FlowButtonType, processType: ProcessType) -> ClearentPrimaryButton {
         let button = ClearentPrimaryButton(title: userAction.title)
         button.action = { [weak self] in
             guard let strongSelf = self, let presenter = strongSelf.presenter else { return }
@@ -136,7 +136,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
             case .cancel, .done:
                 strongSelf.dismissViewController()
             case .retry, .pair:
-                presenter.restartProcess(processType: proccessType)
+                presenter.restartProcess(processType: processType)
             }
         }
         return button

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -62,7 +62,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         stackView.addArrangedSubview(loadingView)
     }
     
-    public func dismissView() {
+    public func dismissViewController() {
         dismiss(animated: true, completion: nil)
         ClearentWrapper.shared.cancelTransaction()
     }
@@ -134,7 +134,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
             guard let strongSelf = self, let presenter = strongSelf.presenter else { return }
             switch userAction {
             case .cancel, .done:
-                strongSelf.dismissView()
+                strongSelf.dismissViewController()
             case .retry, .pair:
                 presenter.restartProcess(processType: proccessType)
             }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Assets/Localizable.strings
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Assets/Localizable.strings
@@ -12,7 +12,7 @@
 "xsdk_pair_new_reader" = "Pair new reader";
 "xsdk_press_reader_button" = "Press the button on reader";
 "xsdk_select_reader" = "Please select the reader you wish to pair with";
-"xsdk_connecting_reader" = "Connecting";
+"xsdk_connecting_reader" = "Connecting...";
 "xsdk_connection_sucesfull" = "Connection successful";
 "xsdk_prepare_pairing_reader_range" = "Please make sure your reader is turned on and in range of the mobile device pairing it";
 "xsdk_prepare_pairing_reader_button" = "Press and hold the button on the side of the reader to turn it on.";

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentPairingReaderItem.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentPairingReaderItem.swift
@@ -55,7 +55,7 @@ class ClearentPairingReaderItem: ClearentMarginableView {
         container.layer.cornerRadius = container.bounds.height / 4
         container.layer.masksToBounds = true
         textColor = ClearentConstants.Color.base01
-        textFont = ClearentConstants.Font.regularSmall
+        textFont = ClearentConstants.Font.regularNormal
         containerBackgroundColor = ClearentConstants.Color.backgroundSecondary03
         rightIconName = ClearentConstants.IconName.rightArrow
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderConnectivityStatusView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderConnectivityStatusView.swift
@@ -11,11 +11,31 @@ import UIKit
 class ClearentReaderConnectivityStatusView: ClearentXibView {
     @IBOutlet weak var statusImageView: UIImageView!
     @IBOutlet weak var statusLabel: UILabel!
+    
+    var textColor: UIColor? {
+        didSet {
+            statusLabel.textColor = textColor
+        }
+    }
 
+    public var font: UIFont? {
+        didSet {
+            statusLabel.font = font
+        }
+    }
+    override func configure() {
+        textColor = ClearentConstants.Color.base02
+        font = ClearentConstants.Font.regularSmall
+    }
+    
     // MARK: Public
 
-    public func setup(imageName: String, status: String) {
-        statusImageView.image = UIImage(named: imageName, in: ClearentConstants.bundle, compatibleWith: nil)
+    public func setup(imageName: String?, status: String) {
         statusLabel.text = status
+        guard let imageName = imageName else {
+            statusImageView.removeFromSuperview()
+            return
+        }
+        statusImageView.image = UIImage(named: imageName, in: ClearentConstants.bundle, compatibleWith: nil)
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderConnectivityStatusView.xib
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderConnectivityStatusView.xib
@@ -7,50 +7,47 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <array key="SF-Pro-Text-Regular.otf">
-            <string>SFProText-Regular</string>
-        </array>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ClearentReaderConnectivityStatusView" customModule="ClearentIdtechIOSFramework" customModuleProvider="target">
             <connections>
-                <outlet property="statusImageView" destination="Ehc-jD-soA" id="HW1-Oa-wdm"/>
-                <outlet property="statusLabel" destination="DqH-kv-sQv" id="8KF-Zm-ill"/>
+                <outlet property="statusImageView" destination="0hl-cJ-VPI" id="qLE-aN-8RB"/>
+                <outlet property="statusLabel" destination="Iv5-IK-Una" id="bXY-g5-5Cc"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="168" height="61"/>
+            <rect key="frame" x="0.0" y="0.0" width="267" height="74"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ehc-jD-soA">
-                    <rect key="frame" x="0.0" y="25" width="12" height="11"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="12" id="GQZ-0r-r3N"/>
-                        <constraint firstAttribute="height" constant="11" id="Qni-MS-TSO"/>
-                    </constraints>
-                </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DqH-kv-sQv">
-                    <rect key="frame" x="18" y="0.0" width="150" height="61"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <fontDescription key="fontDescription" name="SFProText-Regular" family="SF Pro Text" pointSize="10"/>
-                    <color key="textColor" red="0.41568627450980389" green="0.42745098039215684" blue="0.49019607843137253" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="0Rn-Hq-Zqh">
+                    <rect key="frame" x="0.0" y="0.0" width="267" height="74"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0hl-cJ-VPI">
+                            <rect key="frame" x="0.0" y="31.5" width="12" height="11"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="12" id="Cib-xo-BO0"/>
+                                <constraint firstAttribute="height" constant="11" id="fvv-rC-Jya"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iv5-IK-Una">
+                            <rect key="frame" x="18" y="27" width="249" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="DqH-kv-sQv" secondAttribute="bottom" id="0j3-iG-WsD"/>
-                <constraint firstItem="DqH-kv-sQv" firstAttribute="leading" secondItem="Ehc-jD-soA" secondAttribute="trailing" constant="6" id="4p9-Rl-uLv"/>
-                <constraint firstAttribute="top" secondItem="DqH-kv-sQv" secondAttribute="top" id="EyS-Bq-SBi"/>
-                <constraint firstItem="Ehc-jD-soA" firstAttribute="centerY" secondItem="DqH-kv-sQv" secondAttribute="centerY" id="GYT-N1-m2f"/>
-                <constraint firstAttribute="trailing" secondItem="DqH-kv-sQv" secondAttribute="trailing" id="VFb-oh-A4h"/>
-                <constraint firstItem="Ehc-jD-soA" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="rPp-LR-pL0"/>
+                <constraint firstItem="0Rn-Hq-Zqh" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="RPd-bN-nU9"/>
+                <constraint firstItem="0Rn-Hq-Zqh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="XCV-gl-A1J"/>
+                <constraint firstAttribute="bottom" secondItem="0Rn-Hq-Zqh" secondAttribute="bottom" id="pVo-Qc-7Cy"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="0Rn-Hq-Zqh" secondAttribute="trailing" id="uNG-2j-5cP"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-52.173913043478265" y="-158.37053571428569"/>
+            <point key="canvasLocation" x="19.565217391304348" y="-154.01785714285714"/>
         </view>
     </objects>
 </document>

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentReaderStatusHeaderView.swift
@@ -25,7 +25,7 @@ public class ClearentReaderStatusHeaderView: ClearentMarginableView {
     // MARK: Public
     
     public func setup(readerName: String,
-                      signalStatusIconName: String,
+                      signalStatusIconName: String?,
                       signalStatusTitle: String,
                       batteryStatusIconName: String?,
                       batteryStatusTitle: String?) {

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentConstants.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentConstants.swift
@@ -38,7 +38,8 @@ class ClearentConstants {
         static let boldNormal = UIFont(name: sfProBold, size: 16)
         static let medium = UIFont(name: sfProMedium, size: 16)
         static let mediumSmall = UIFont(name: sfProMedium, size: 14)
-        static let regularSmall = UIFont(name: sfProRegular, size: 14)
+        static let regularNormal = UIFont(name: sfProRegular, size: 14)
+        static let regularSmall = UIFont(name: sfProRegular, size: 10)
     }
 
     // MARK: Assets

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/Identifiers.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/Identifiers.swift
@@ -16,7 +16,7 @@ enum FlowDataKeys {
     case readerInfo, graphicType, title, description, userAction, devicesFound, hint
 }
 
-enum FlowFeedbackType {
+public enum FlowFeedbackType {
     case error, info, warning, searchDevices
 }
 

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/ReaderInfo.swift
@@ -26,9 +26,9 @@ public struct ReaderInfo : Codable {
 }
 
 public extension ReaderInfo {
-    var batteryStatus: (iconName: String?, title: String?) {
+    func batteryStatus(flowFeedbackType: FlowFeedbackType? = nil) -> (iconName: String?, title: String?) {
         // if reader is not connected, battery should not be shown
-        guard let batteryLevel = batterylevel, isConnected else {
+        guard let batteryLevel = batterylevel, isConnected, flowFeedbackType != .searchDevices else {
             return (nil, nil)
         }
         var iconName = ClearentConstants.IconName.batteryLow
@@ -40,12 +40,15 @@ public extension ReaderInfo {
         return (iconName, "\(String(batteryLevel))%")
     }
 
-    var signalStatus: (iconName: String, title: String) {
+    func signalStatus(flowFeedbackType: FlowFeedbackType? = nil) -> (iconName: String?, title: String) {
+        var icon = ClearentConstants.IconName.signalIdle
         guard let signalLevel = signalLevel, isConnected else {
-            return (iconName: ClearentConstants.IconName.signalIdle, title: "xsdk_reader_signal_idle".localized)
+            if flowFeedbackType == .searchDevices {
+                return (iconName: nil, title: "xsdk_connecting_reader".localized)
+            }
+            return (iconName: icon, title: "xsdk_reader_signal_idle".localized)
         }
 
-        var icon = ClearentConstants.IconName.signalIdle
         switch signalLevel {
         case 0:
             icon = ClearentConstants.IconName.goodSignal
@@ -56,7 +59,7 @@ public extension ReaderInfo {
         default:
             icon = ClearentConstants.IconName.signalIdle
         }
-
-        return (iconName: icon, title: "xsdk_reader_signal_connected".localized)
+        let title = flowFeedbackType == .searchDevices ? "xsdk_connection_sucesfull".localized : "xsdk_reader_signal_connected".localized
+        return (iconName: icon, title: title)
     }
 }

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentWrapper.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentWrapper.swift
@@ -334,7 +334,7 @@ extension ClearentWrapper : Clearent_Public_IDTech_VP3300_Delegate {
     public func deviceConnected() {
         readerInfo?.isConnected = true
         bleManager?.setupDevice()
-        bleManager?.readRSSI()
+        startDeviceInfoUpdate()
         ClearentWrapperDefaults.pairedReaderInfo = readerInfo
         if let newReader = readerInfo {
             addReaderToRecentlyUsed(reader: newReader)


### PR DESCRIPTION
Added changes:
- display reader battery and signal status when pairing is successful
- due to the fact that some texts/icons are different than the ones from payment flow, some adjustments were needed
