### PR TITLE
Bug/#11682: incorrect behaviour when autojoin is off

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -93,6 +93,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         case .hint:
             guard let text = object as? String else { return nil }
             
+            return ClearentHintView(text: text)
         case .recentlyPaired:
             guard let readersInfo = object as? [ReaderInfo] else { return nil }
             var readersTableViewDataSource: [ReaderItem] = readersInfo.map { ReaderItem(readerInfo: $0) }

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -93,7 +93,6 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         case .hint:
             guard let text = object as? String else { return nil }
             
-            return ClearentHintView(text: text)
         case .recentlyPaired:
             guard let readersInfo = object as? [ReaderInfo] else { return nil }
             var readersTableViewDataSource: [ReaderItem] = readersInfo.map { ReaderItem(readerInfo: $0) }
@@ -114,7 +113,8 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         }
     }
 
-    private func readerInfoView(readerInfo: ReaderInfo?, flowFeedbackType: FlowFeedbackType) -> ClearentReaderStatusHeaderView {
+    private func readerInfoView(readerInfo: ReaderInfo?, flowFeedbackType: FlowFeedbackType) -> ClearentReaderStatusHeaderView? {
+        if readerInfo == nil && flowFeedbackType != .showReaders { return nil }
         let name = readerInfo?.readerName ?? "xsdk_readers_list_no_reader_connected".localized
         let description = readerInfo == nil ? "xsdk_readers_list_select_reader".localized : nil
         let signalStatus = readerInfo?.signalStatus(flowFeedbackType: flowFeedbackType, isConnecting: presenter?.selectedReaderFromReadersList != nil)

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
@@ -274,20 +274,20 @@ extension FlowDataProvider : ClearentWrapperProtocol {
         let items: [FlowDataItem]
         let feedback: FlowFeedback
         
-        if case .pairing = ClearentWrapper.shared.flowType {
-            items = [FlowDataItem(type: .graphicType, object: FlowGraphicType.loading),
-                     FlowDataItem(type: .graphicType, object: FlowGraphicType.pairedReader)]
-            feedback = FlowDataFactory.component(with: .pairing(),
-                                                 type: .searchDevices,
-                                                 readerInfo: reader,
-                                                 payload: items)
-        } else {
+        if case .showReaders = ClearentWrapper.shared.flowType {
             guard let recentlyPairedDevices = ClearentWrapperDefaults.recentlyPairedReaders else { return }
             
             items = [FlowDataItem(type: .recentlyPaired, object: recentlyPairedDevices),
                      FlowDataItem(type: .userAction, object: FlowButtonType.pairNewReader)]
             feedback = FlowDataFactory.component(with: .showReaders,
                                                  type: .showReaders,
+                                                 readerInfo: reader,
+                                                 payload: items)
+        } else {
+            items = [FlowDataItem(type: .graphicType, object: FlowGraphicType.loading),
+                     FlowDataItem(type: .graphicType, object: FlowGraphicType.pairedReader)]
+            feedback = FlowDataFactory.component(with: .pairing(),
+                                                 type: .searchDevices,
                                                  readerInfo: reader,
                                                  payload: items)
         }


### PR DESCRIPTION
**Steps to reproduce:**
Access the "Reader details" screen of the currently paired and connected reader;
Turn off "Auto-join";
Restart the app and reach the "Home" screen;
Input an amount, then press on "Charge";
 From the list of available readers, select the previously connected to reader;


**Expected result:**
Reader connects and the "Please tap, swipe, or insert your card." screen is displayed.

**Actual result:**
A pseudo-reader list, which cannot be dismissed, is displayed at the bottom of the screen.