### PR TITLE
#12227: adapt details screen to accommodate the new implementation of the readers list

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
@@ -109,7 +109,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
     
     func showDetailsScreen(for reader: ReaderItem, allReaders: [ReaderItem], flowDataProvider: FlowDataProvider, on navigationController: UINavigationController)  {
         let vc = ClearentReaderDetailsViewController(nibName: String(describing: ClearentReaderDetailsViewController.self), bundle: ClearentConstants.bundle)
-        vc.detailsPresenter = ClearentReaderDetailsPresenter(currentReader: reader, allReaders: allReaders, flowDataProvider: flowDataProvider, navigationController: navigationController)
+        vc.detailsPresenter = ClearentReaderDetailsPresenter(currentReader: reader, flowDataProvider: flowDataProvider, navigationController: navigationController)
         navigationController.pushViewController(vc, animated: true)
     }
     

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -176,7 +176,7 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
                     if (flowFeedbackType == .renameReaderDone) {
                         presenter.updateReaderName()
                     }
-                    strongSelf.dismissViewController(isConnected: userAction == .done, customName: ClearentWrapperDefaults.pairedReaderInfo?.customReaderName)
+                    strongSelf.dismissViewController(isConnected: userAction != .cancel, customName: ClearentWrapperDefaults.pairedReaderInfo?.customReaderName)
                 }
             case .retry, .pair:
                 presenter.restartProcess(processType: processType, newPair: false)

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import AVFAudio
 
 private struct DefaultKeys {
     static let readerFriendlyNameKey = "xsdk_reader_friendly_name_key"
@@ -63,6 +64,14 @@ extension ClearentWrapperDefaults {
         }
         set {
             ClearentWrapper.shared.readerInfoReceived?(newValue)
+            // previously paired readers list should be in sync with the current paired reader
+            if let pairedReader = newValue {
+                ClearentWrapper.shared.addReaderToRecentlyUsed(reader: pairedReader)
+            } else if var oldPairedReader = defaultReaderInfo {
+                oldPairedReader.isConnected = false
+                oldPairedReader.autojoin = false
+                ClearentWrapper.shared.updateReaderInRecentlyUsed(reader: oldPairedReader)
+            }
             defaultReaderInfo = newValue
         }
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentWrapperDefaults.swift
@@ -64,10 +64,11 @@ extension ClearentWrapperDefaults {
         }
         set {
             ClearentWrapper.shared.readerInfoReceived?(newValue)
-            // previously paired readers list should be in sync with the current paired reader
+            // current paired reader should be in sync with the corresponding item from previously paired readers
             if let pairedReader = newValue {
                 ClearentWrapper.shared.addReaderToRecentlyUsed(reader: pairedReader)
-            } else if var oldPairedReader = defaultReaderInfo {
+            } // if pairedReader is nil, we need to set connected and autojoin to false in the previously paired readers
+            else if var oldPairedReader = defaultReaderInfo {
                 oldPairedReader.isConnected = false
                 oldPairedReader.autojoin = false
                 ClearentWrapper.shared.updateReaderInRecentlyUsed(reader: oldPairedReader)

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
@@ -325,9 +325,9 @@ extension FlowDataProvider : ClearentWrapperProtocol {
     }
     
     private func createFeedbackForSuccessfulPairing() {
-        guard var recentlyPairedReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
-        guard let pairedReaderInfo = ClearentWrapperDefaults.pairedReaderInfo else { return }
-        guard let indexOfSelectedReader = recentlyPairedReaders.firstIndex(where: {$0 == pairedReaderInfo}) else { return }
+        guard var recentlyPairedReaders = ClearentWrapperDefaults.recentlyPairedReaders,
+              let pairedReaderInfo = ClearentWrapperDefaults.pairedReaderInfo,
+              let indexOfSelectedReader = recentlyPairedReaders.firstIndex(where: {$0 == pairedReaderInfo}) else { return }
         
         recentlyPairedReaders[indexOfSelectedReader] = pairedReaderInfo
         

--- a/ClearentIdtechIOSFramework/ClearentUI/ReaderDetails/ClearentReaderDetailsPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ReaderDetails/ClearentReaderDetailsPresenter.swift
@@ -18,7 +18,6 @@ protocol ClearentReaderDetailsProtocol {
 
 class ClearentReaderDetailsPresenter: ClearentReaderDetailsProtocol {
     public var currentReader: ReaderInfo
-    private var allReaders: [ReaderItem]
     private var flowDataProvider: FlowDataProvider
     private var navigationController: UINavigationController?
 
@@ -43,9 +42,8 @@ class ClearentReaderDetailsPresenter: ClearentReaderDetailsProtocol {
         return (title, batteryStatus.iconName)
     }
 
-    init(currentReader: ReaderItem, allReaders: [ReaderItem], flowDataProvider: FlowDataProvider, navigationController: UINavigationController) {
+    init(currentReader: ReaderItem, flowDataProvider: FlowDataProvider, navigationController: UINavigationController) {
         self.currentReader = currentReader.readerInfo
-        self.allReaders = allReaders
         self.flowDataProvider = flowDataProvider
         self.navigationController = navigationController
     }
@@ -86,9 +84,7 @@ class ClearentReaderDetailsPresenter: ClearentReaderDetailsProtocol {
 
     func handleBackAction() {
         if ClearentWrapperDefaults.pairedReaderInfo != nil || !ClearentWrapper.shared.previouslyPairedReaders.isEmpty {
-            let readerInfoList = allReaders.map { $0.readerInfo }
-            let result = ClearentWrapper.shared.fetchRecentlyAndAvailableReaders(availableReaders: readerInfoList)
-            flowDataProvider.didFindRecentlyUsedReaders(readers: result)
+            flowDataProvider.didFindRecentlyUsedReaders(readers: ClearentWrapper.shared.previouslyPairedReaders)
             navigationController?.popViewController(animated: true)
         } else {
             ClearentWrapper.shared.readerInfoReceived?(nil)

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentExtension.swift
@@ -37,11 +37,7 @@ extension ClearentWrapper: BluetoothScannerProtocol {
 extension ClearentWrapper {
     
     internal func addReaderToRecentlyUsed(reader: ReaderInfo) {
-        var reader = reader
-        reader.isConnected = false
         guard var existingReaders = ClearentWrapperDefaults.recentlyPairedReaders, !existingReaders.isEmpty else {
-            reader.autojoin = true
-            ClearentWrapperDefaults.pairedReaderInfo?.autojoin = true
             ClearentWrapperDefaults.recentlyPairedReaders = [reader]
             return
         }
@@ -53,27 +49,18 @@ extension ClearentWrapper {
         ClearentWrapperDefaults.recentlyPairedReaders = existingReaders
     }
     
+    internal func updateReaderInRecentlyUsed(reader: ReaderInfo) {
+        guard var existingReaders = ClearentWrapperDefaults.recentlyPairedReaders, !existingReaders.isEmpty else { return }
+        if let defaultReaderIndex = existingReaders.firstIndex(where: { $0 == reader }) {
+            existingReaders[defaultReaderIndex] = reader
+        }
+        ClearentWrapperDefaults.recentlyPairedReaders = existingReaders
+    }
+    
     internal func removeReaderFromRecentlyUsed(reader: ReaderInfo) {
         guard var existingReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return }
         existingReaders.removeAll(where: { $0 == reader })
         ClearentWrapperDefaults.recentlyPairedReaders = existingReaders
-    }
-    
-    internal func fetchRecentlyAndAvailableReaders(devices: [ClearentBluetoothDevice]) -> [ReaderInfo] {
-        let availableReaders = devices.compactMap { readerInfo(from: $0)}
-        return fetchRecentlyAndAvailableReaders(availableReaders: availableReaders)
-    }
-    
-    internal func fetchRecentlyAndAvailableReaders(availableReaders: [ReaderInfo]) -> [ReaderInfo] {
-        guard let recentReaders = ClearentWrapperDefaults.recentlyPairedReaders else { return [] }
-        var result = recentReaders.filter { recentReader in availableReaders.contains(where: {
-            $0 == recentReader && $0 != ClearentWrapperDefaults.pairedReaderInfo
-        })}
-        // always include default reader
-        if let defaultReader = ClearentWrapperDefaults.pairedReaderInfo {
-            result.insert(defaultReader, at: 0)
-        }
-        return result
     }
     
     internal func readerInfo(from clearentDevice:ClearentBluetoothDevice) -> ReaderInfo {

--- a/ClearentIdtechIOSFramework/Wrapper/ClearentWrapper.swift
+++ b/ClearentIdtechIOSFramework/Wrapper/ClearentWrapper.swift
@@ -445,14 +445,15 @@ extension ClearentWrapper : Clearent_Public_IDTech_VP3300_Delegate {
     }
     
     public func deviceConnected() {
-        if var currentReader = ClearentWrapperDefaults.pairedReaderInfo {
-            currentReader.isConnected = true
-            ClearentWrapperDefaults.pairedReaderInfo = currentReader
-            addReaderToRecentlyUsed(reader: currentReader)
-        }
         bleManager?.udid = ClearentWrapperDefaults.pairedReaderInfo?.uuid
         bleManager?.setupDevice()
         startDeviceInfoUpdate()
+
+        // if there is no autojoin reader, set the current connected reader with autojoin true
+        if ClearentWrapperDefaults.recentlyPairedReaders?.first(where: { $0.autojoin == true }) == nil {
+            ClearentWrapperDefaults.pairedReaderInfo?.autojoin = true
+        }
+        ClearentWrapperDefaults.pairedReaderInfo?.isConnected = true
         self.delegate?.didFinishPairing()
     }
     


### PR DESCRIPTION
As the readers list should now contain previously paired readers, we need to make sure the current paired reader is always in sync with the corresponding item from the list