### PR TITLE
[iOS][Offline mode] Warning messages not displayed when feature is ON in app

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalPresenter.swift
@@ -160,6 +160,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
         case .cancel:
             ClearentWrapper.shared.isNewPaymentProcess = true
             ClearentWrapper.shared.isOfflineModeConfirmed = false
+            ClearentWrapper.shared.offlineModeWarningDisplayed = false
             modalProcessingView?.dismissViewController(result: .failure(.cancelledByUser))
         case .retry, .pair:
             restartProcess(newPair: false)
@@ -184,6 +185,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
             modalProcessingView?.displayOfflineModeConfirmationMessage(for: .denyOfflineMode)
         case .confirmOfflineModeWarningMessage:
             ClearentWrapper.shared.isOfflineModeConfirmed = true
+            ClearentWrapper.shared.offlineModeWarningDisplayed = true
             restartProcess(newPair: false)
         }
     }
@@ -276,6 +278,8 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
         if useCardReaderPaymentMethod, !sdkWrapper.isReaderConnected() {
             shouldStartTransactionAfterRenameReader = ClearentWrapperDefaults.pairedReaderInfo == nil
             sdkWrapper.startPairing(reconnectIfPossible: true)
+        } else if ClearentWrapper.shared.enableOfflineMode, ClearentWrapper.shared.offlineModeState == .on, !ClearentWrapper.shared.offlineModeWarningDisplayed {
+            sdkFeedbackProvider.displayOfflineModeWarningMessage()
         } else {
             startTipFlow()
         }

--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentProcessingModalViewController.swift
@@ -80,7 +80,10 @@ extension ClearentProcessingModalViewController: ClearentProcessingModalView {
         }
         
         if ClearentWrapper.shared.enableOfflineMode {
-            if (ClearentWrapper.shared.offlineModeState == .on) || (ClearentWrapper.shared.offlineModeState == .prompted && ClearentWrapper.shared.flowType?.processType == .payment && ClearentWrapper.shared.isOfflineModeConfirmed) {
+            let offlineModeConfirmedDuringPayment = ClearentWrapper.shared.flowType?.processType == .payment && ClearentWrapper.shared.offlineModeState != .off && ClearentWrapper.shared.isOfflineModeConfirmed
+            let offlineModeEnabled = [.pairing(), .showReaders].contains(ClearentWrapper.shared.flowType?.processType) && ClearentWrapper.shared.offlineModeState == .on
+            
+            if offlineModeConfirmedDuringPayment || offlineModeEnabled {
                 stackView.insertArrangedSubview(ClearentSubtitleLabel(text: ClearentConstants.Localized.OfflineMode.offlineModeEnabled), at: 1)
             }
         }

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
@@ -37,7 +37,7 @@ public final class ClearentWrapper : NSObject {
     public var enableOfflineMode: Bool = false
     
     /// The state of the store & forward feature
-    public var offlineModeState: OfflineModeState = .on
+    public var offlineModeState: OfflineModeState = .off
     
     /// Stores the enhanced messages read from the messages bundle
     internal var enhancedMessagesDict: [String:String]?
@@ -68,10 +68,7 @@ public final class ClearentWrapper : NSObject {
             return false
         } else {
             switch offlineModeState {
-            case .off:
-                return false
-            case .on:
-                isOfflineModeConfirmed = true
+            case .off, .on:
                 return false
             case .prompted:
                 return !isInternetOn ? (isNewPaymentProcess ? true : false) : false
@@ -84,6 +81,7 @@ public final class ClearentWrapper : NSObject {
     internal var isBluetoothOn = false
     internal var tipEnabled = false
     internal var isOfflineModeConfirmed = false
+    internal var offlineModeWarningDisplayed = false
     internal var shouldSendPressButton = false
     internal var isNewPaymentProcess = true
     private var continuousSearchingTimer: Timer?
@@ -430,9 +428,9 @@ public final class ClearentWrapper : NSObject {
     private func getConnectivityStatus(for processType: ProcessType) -> UserAction? {
         if processType == .payment {
             if cardReaderPaymentIsPreffered && useManualPaymentAsFallback == nil {
-                return isBluetoothPermissionGranted ? (isInternetOn ? (isBluetoothOn ? nil : .noBluetooth) : (isOfflineModeConfirmed ? nil : .noInternet)) : .noBluetoothPermission
+                return isBluetoothPermissionGranted ? (isInternetOn ? (isBluetoothOn ? nil : .noBluetooth) : ((isOfflineModeConfirmed || offlineModeState == .on) ? nil : .noInternet)) : .noBluetoothPermission
             } else {
-                return isInternetOn ? nil : (isOfflineModeConfirmed ? nil : .noInternet)
+                return isInternetOn ? nil : ((isOfflineModeConfirmed || offlineModeState == .on) ? nil : .noInternet)
             }
         } else {
             return isBluetoothPermissionGranted ? (isBluetoothOn ? nil : .noBluetooth) : .noBluetoothPermission


### PR DESCRIPTION
Changed the way the offline mode warning message is displayed.
It will appear before any transaction when the feature is enabled and turned on and also after the user confirms the offline mode when in prompted state.