### PR TITLE
Feature/#19863 fail transaction if unencrypted reader

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentDelegate.m
+++ b/ClearentIdtechIOSFramework/ClearentDelegate.m
@@ -1789,8 +1789,8 @@ BOOL isEncryptedTransaction (NSDictionary* encryptedTags) {
     [self deviceMessage:CLEARENT_TRANSLATING_CARD_TO_TOKEN];
     
     // If we are in offline mode call the delegate and stop
-    if (self.offlineMode && [self.publicDelegate respondsToSelector:@selector(successOfflineTransactionToken:)]) {
-        [self.publicDelegate successOfflineTransactionToken:postData];
+    if (self.offlineMode && [self.publicDelegate respondsToSelector:@selector(successOfflineTransactionToken: isTransactionEncrypted:)]) {
+        [self.publicDelegate successOfflineTransactionToken:postData isTransactionEncrypted:clearentTransactionTokenRequest.encrypted];
         
         processingCurrentRequest = NO;
         return;

--- a/ClearentIdtechIOSFramework/ClearentPublicVP3300Delegate.h
+++ b/ClearentIdtechIOSFramework/ClearentPublicVP3300Delegate.h
@@ -24,7 +24,7 @@
 /**
 * This will notify you when a ClearentTransactionTokenRequest has been created, this will only be called when the SDK is in offline mode.
 */
--(void) successOfflineTransactionToken:(NSData *) clearentTokenRequestData;
+-(void) successOfflineTransactionToken:(NSData *) clearentTokenRequestData isTransactionEncrypted:(BOOL)isEncrypted;
 
 /**
  *  When the framework wants to communicate back it will call this method.

--- a/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
@@ -195,8 +195,16 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
             sdkFeedbackProvider.delegate = self
             modalProcessingView?.showLoadingView()
             
-            useCardReaderPaymentMethod ? startCardReaderTransaction() : startManualEntryTransaction()
-            
+            // check if the reader is encrypted and show the proper warning message
+            if let isReaderEncrypted = sdkWrapper.isReaderEncrypted(), useCardReaderPaymentMethod {
+               if !isReaderEncrypted {
+                   sdkFeedbackProvider.showEncryptionWarning()
+               } else {
+                   startCardReaderTransaction()
+               }
+            } else {
+                useCardReaderPaymentMethod ? startCardReaderTransaction() : startManualEntryTransaction()
+            }
         }
     }
     

--- a/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
@@ -195,7 +195,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
             sdkFeedbackProvider.delegate = self
             modalProcessingView?.showLoadingView()
             
-            // check if the reader is encrypted and show the proper warning message
+            // Check if the card reader is encrypted and show the proper warning message
             if let isReaderEncrypted = sdkWrapper.isReaderEncrypted(), useCardReaderPaymentMethod {
                if !isReaderEncrypted {
                    sdkFeedbackProvider.showEncryptionWarning()

--- a/ClearentIdtechIOSFramework/ClearentWrapper/ReaderInfo.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/ReaderInfo.swift
@@ -28,6 +28,7 @@ public struct ReaderInfo: Codable {
     public var uuid: UUID?
     public var serialNumber: String?
     public var version: String?
+    public var encrypted: Bool?
 }
 
 extension ReaderInfo: Equatable {

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentReaderRepository.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentReaderRepository.swift
@@ -141,12 +141,7 @@ class ReaderRepository: ReaderRepositoryProtocol {
     }
     
     func isReaderEncrypted() -> Bool? {
-        var response: NSData? = NSData()
-        _ = clearentVP3300.device_sendIDGCommand(0xC7, subCommand: 0x37, data: nil, response: &response)
-        
-        guard let response = response else { return nil }
-        
-        return response.int == 3
+        return ClearentWrapperDefaults.pairedReaderInfo?.encrypted
     }
     
     func deviceConnected() {
@@ -215,7 +210,7 @@ class ReaderRepository: ReaderRepositoryProtocol {
         let uuid: UUID? = UUID(uuidString: clearentDevice.deviceId)
         let customReader = readerFromRecentlyPaired(uuid: uuid)
             
-        return ReaderInfo(readerName: clearentDevice.friendlyName, customReaderName: customReader?.customReaderName, batterylevel: nil, signalLevel: nil, isConnected: clearentDevice.connected, autojoin: customReader?.autojoin ?? false, uuid: uuid, serialNumber: nil, version: nil)
+        return ReaderInfo(readerName: clearentDevice.friendlyName, customReaderName: customReader?.customReaderName, batterylevel: nil, signalLevel: nil, isConnected: clearentDevice.connected, autojoin: customReader?.autojoin ?? false, uuid: uuid, serialNumber: nil, version: nil, encrypted: nil)
     }
     
     func invalidateConnectionTimer() {

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
@@ -436,10 +436,17 @@ extension ClearentWrapper: Clearent_Public_IDTech_VP3300_Delegate {
         }
     }
     
-    public func successOfflineTransactionToken(_ clearentTransactionTokenRequestData: Data?) {
+    public func successOfflineTransactionToken(_ clearentTransactionTokenRequestData: Data?, isTransactionEncrypted isEncrypted: Bool) {
         guard let cardToken = clearentTransactionTokenRequestData else { return }
-        let paymentData = PaymentData(saleEntity: saleEntity, cardToken: cardToken)
         
+        ClearentWrapperDefaults.pairedReaderInfo?.encrypted = isEncrypted
+        if (!isEncrypted) {
+            self.delegate?.showEncryptionWarning()
+            disableOfflineMode()
+            return
+        }
+        
+        let paymentData = PaymentData(saleEntity: saleEntity, cardToken: cardToken)
         transactionRepository?.saveOfflineTransaction(paymentData: paymentData)
     }
     


### PR DESCRIPTION
We are no longer using the command method to check for  reader's encryption.

When the user processes a transaction for the first time we take the encrypted flag from the ClearentTokenRequest and save it on the read. Also showing the encryption warning and setting offline mode to off.

Second time the user tries a offline transaction with an unencrypted reader we check the reader's new encrypted property.