### PR TITLE
Feature/#22731: Create default 'software type'  for ISV partners that do not send software type

### DIFF
--- a/ClearentIdtechIOSFramework/ClearentUI/ClearentBaseViewController.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/ClearentBaseViewController.swift
@@ -1,6 +1,6 @@
 //
 //  ClearentBaseViewController.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 10.05.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Model/ClearentManualPaymentModel.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Model/ClearentManualPaymentModel.swift
@@ -104,7 +104,7 @@ class CardNoItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = "4111 1111 1111 1111"
+    var enteredValue: String = ""
 
     var hiddenValue: String?
 }
@@ -128,7 +128,7 @@ class DateItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = "12/23"
+    var enteredValue: String = ""
 
     var hiddenValue: String?
 }
@@ -150,7 +150,7 @@ class SecurityCodeItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = "999"
+    var enteredValue: String = ""
 
     var hiddenValue: String?
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Model/ClearentManualPaymentModel.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Model/ClearentManualPaymentModel.swift
@@ -104,7 +104,7 @@ class CardNoItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = ""
+    var enteredValue: String = "4111 1111 1111 1111"
 
     var hiddenValue: String?
 }
@@ -128,7 +128,7 @@ class DateItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = ""
+    var enteredValue: String = "12/23"
 
     var hiddenValue: String?
 }
@@ -150,7 +150,7 @@ class SecurityCodeItem: ClearentPaymentItem {
 
     var isValid: Bool = true
 
-    var enteredValue: String = ""
+    var enteredValue: String = "999"
 
     var hiddenValue: String?
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentAdaptiveStackView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentAdaptiveStackView.swift
@@ -1,6 +1,6 @@
 //
 //  AdaptiveStackView.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 07.04.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentMarginable.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentMarginable.swift
@@ -1,6 +1,6 @@
 //
 //  ClearentMarginable.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 06.04.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentMarginableView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentMarginableView.swift
@@ -1,6 +1,6 @@
 //
 //  ClearentMarginableView.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 07.04.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentXibView.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/AdaptiveStackView/ClearentXibView.swift
@@ -1,6 +1,6 @@
 //
 //  ClearentXibView.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 07.04.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentEmptySpace.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentEmptySpace.swift
@@ -1,6 +1,6 @@
 //
 //  ClearentEmptySpace.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 07.04.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentTitleLabel.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/UIComponents/ClearentTitleLabel.swift
@@ -18,6 +18,7 @@ public class ClearentTitleLabel: ClearentMarginableView {
             RelativeBottomMargin(constant: 24, relatedViewType: ClearentListView.self),
             RelativeBottomMargin(constant: 24, relatedViewType: ClearentPrimaryButton.self),
             RelativeBottomMargin(constant: 10, relatedViewType: ClearentIconAndLabel.self),
+            RelativeBottomMargin(constant: 24, relatedViewType: ClearentServiceFeeView.self),
             BottomMargin(constant: 80)
         ]
     }

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentConstants.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentConstants.swift
@@ -117,6 +117,8 @@ import UIKit
         public static let maxNoOfCharacters = 11
     }
     
+    // MARK: - Localizable
+
     enum Localized {
         enum Internet {
             public static let noConnection = "xsdk_internet_no_connection".localized

--- a/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentMoneyFormatter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Common/Util/ClearentMoneyFormatter.swift
@@ -1,6 +1,6 @@
 //
 //  MoneyFormatter.swift
-//  XplorPayMobile
+//  ClearentIdtechIOSFramework
 //
 //  Created by Carmen Jurcovan on 23.03.2022.
 //

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentFlowDataSource/FlowDataProvider.swift
@@ -96,7 +96,7 @@ class FlowDataProvider : NSObject {
     }
     
     func showServiceFeeScreen(for serviceFeeType: ServiceFeeProgramType) {
-        let items = [ FlowDataItem(type: .hint, object: serviceFeeType.title),
+        let items = [ FlowDataItem(type: .title, object: serviceFeeType.title),
                      FlowDataItem(type: .serviceFee, object: serviceFeeType),
                      FlowDataItem(type: .userAction, object: FlowButtonType.transactionWithServiceFee),
                      FlowDataItem(type: .userAction, object: FlowButtonType.cancel)]

--- a/ClearentIdtechIOSFramework/ClearentUI/PaymentInfo.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/PaymentInfo.swift
@@ -13,13 +13,15 @@
     public var orderID: String?
     public var billing: ClientInformation?
     public var shipping: ClientInformation?
+    public var softwareType: String?
     
-    @objc public init(amount: Double, customerID: String? = nil, invoice: String? = nil, orderID: String? = nil, billing: ClientInformation? = nil, shipping: ClientInformation? = nil) {
+    @objc public init(amount: Double, customerID: String? = nil, invoice: String? = nil, orderID: String? = nil, billing: ClientInformation? = nil, shipping: ClientInformation? = nil, softwareType: String? = nil) {
         self.amount = amount
         self.customerID = customerID
         self.invoice = invoice
         self.orderID = orderID
         self.billing = billing
         self.shipping = shipping
+        self.softwareType = softwareType
     }
 }

--- a/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
+++ b/ClearentIdtechIOSFramework/ClearentUI/Scenes/ClearentProcessingModalPresenter.swift
@@ -257,6 +257,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
         
         let saleEntity = SaleEntity(amount: amount,
                                     tipAmount: tip?.stringFormattedWithTwoDecimals,
+                                    softwareType: paymentInfo?.softwareType,
                                     billing: billingInfo,
                                     shipping: shippingInfo,
                                     card: cardNo,
@@ -368,6 +369,7 @@ extension ClearentProcessingModalPresenter: ProcessingModalProtocol {
         if let amountFormatted = paymentInfo?.amount.stringFormattedWithTwoDecimals {
             let saleEntity = SaleEntity(amount: amountFormatted,
                                         tipAmount: tip?.stringFormattedWithTwoDecimals,
+                                        softwareType: paymentInfo?.softwareType,
                                         billing: paymentInfo?.billing,
                                         shipping: paymentInfo?.shipping,
                                         customerID: paymentInfo?.customerID,

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
@@ -52,6 +52,14 @@ extension SaleEntity {
         static let offlineText = "offline"
         static let platform = "iOS"
     }
+    
+    /**
+     Updates software type based on the following scenarios:
+      1. Our native app is used ->  Xplor Pay Mobile_[offline]_iOS
+                        -> add sdk version to softwareTypeVersion field
+      2. Integrator didn’t add anything -> Xplor Pay SDK_<sdk version>_ [offline]_iOS
+      3. Otherwise -> <integrator's choice>_Xplor Pay SDK_<sdk version>_[offline]_iOS
+     */
     func updateSoftwareType(isOfflineTransaction: Bool) {
         var softwareType = softwareType ?? ""
         let sdkVersion = ClearentWrapper.shared.currentSDKVersion()

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
@@ -63,7 +63,7 @@ extension SaleEntity {
     func updateSoftwareType(isOfflineTransaction: Bool) {
         var softwareType = softwareType ?? ""
         let sdkVersion = ClearentWrapper.shared.currentSDKVersion()
-        if softwareType.lowercased().contains(SoftwareTypeNaming.hostAppTitle) { // check if the Host App is Xplor app
+        if softwareType.lowercased().contains(SoftwareTypeNaming.hostAppTitle) { // checks if the Host App is Xplor app
             softwareTypeVersion = sdkVersion
         } else {
             if !softwareType.isEmpty {

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Networking/Entities/SaleEntity.swift
@@ -44,6 +44,36 @@ public class SaleEntity: CodableProtocol {
     }
 }
 
+extension SaleEntity {
+    enum SoftwareTypeNaming {
+        static let separator = "_"
+        static let sdkTitle = "Xplor Pay SDK"
+        static let hostAppTitle = "xplor"
+        static let offlineText = "offline"
+        static let platform = "iOS"
+    }
+    func updateSoftwareType(isOfflineTransaction: Bool) {
+        var softwareType = softwareType ?? ""
+        let sdkVersion = ClearentWrapper.shared.currentSDKVersion()
+        if softwareType.lowercased().contains(SoftwareTypeNaming.hostAppTitle) { // check if the Host App is Xplor app
+            softwareTypeVersion = sdkVersion
+        } else {
+            if !softwareType.isEmpty {
+                softwareType.append(contentsOf: SoftwareTypeNaming.separator)
+            }
+            softwareType.append(contentsOf: SoftwareTypeNaming.sdkTitle)
+            if let sdkVersion = sdkVersion {
+                softwareType.append(contentsOf: "\(SoftwareTypeNaming.separator)\(sdkVersion)")
+            }
+        }
+        if isOfflineTransaction {
+            softwareType.append(contentsOf: "\(SoftwareTypeNaming.separator)\(SoftwareTypeNaming.offlineText)")
+        }
+        softwareType.append(contentsOf: "\(SoftwareTypeNaming.separator)\(SoftwareTypeNaming.platform)")
+        self.softwareType = softwareType
+    }
+}
+
 // MARK: - ClientInformation
 
 @objc public class ClientInformation: NSObject, Codable {

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Networking/HttpClient/ClearentHttpClient.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Networking/HttpClient/ClearentHttpClient.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-private struct ClientInfo {
-    static let softwareType = "Xplor iOS Mobile"
-    static let softwareTypeVersion = "1.0"
-}
 
 private struct ClearentEndpoints {
     static let sale: String = "/rest/v2/mobile/transactions/sale"
@@ -110,8 +106,6 @@ class ClearentDefaultHttpClient: ClearentHttpClientProtocol {
     }
     
     private func transactionBody(type:String, saleEntity: SaleEntity) -> HttpClient.HTTPBody {
-        saleEntity.softwareType = ClientInfo.softwareType
-        saleEntity.softwareTypeVersion = ClientInfo.softwareTypeVersion
         let body = HttpClient.HTTPBody.codableObject(saleEntity, HttpClient.ParameterEncoding.json)
         return body
     }
@@ -125,7 +119,7 @@ class ClearentDefaultHttpClient: ClearentHttpClientProtocol {
     }
     
     private func voidHTTPMethod(transactionID:String) -> HttpClient.HTTPMethod {
-        let paramsDictionary = ["id":transactionID, "type":TransactionType.void.rawValue, "software-type": ClientInfo.softwareType, "software-type-version":ClearentWrapper.shared.currentSDKVersion() ?? "-"]
+        let paramsDictionary = ["id":transactionID, "type":TransactionType.void.rawValue]
         let body = HttpClient.HTTPBody.parameters(paramsDictionary, HttpClient.ParameterEncoding.json)
         return HttpClient.HTTPMethod.POST(body)
     }

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentReaderRepository.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentReaderRepository.swift
@@ -222,7 +222,7 @@ class ReaderRepository: ReaderRepositoryProtocol {
     }
     
     func cardReaderTransaction() {
-        let dispatchQueue = DispatchQueue(label: "xplor.UserInteractiveQueue", qos: .userInteractive, attributes: .concurrent)
+        let dispatchQueue = DispatchQueue(label: "xsdk.UserInteractiveQueue", qos: .userInteractive, attributes: .concurrent)
         dispatchQueue.async { [weak self] in
             guard let strongSelf = self else { return }
             strongSelf.startDeviceInfoUpdate()

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentTransactionRepository.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentTransactionRepository.swift
@@ -9,7 +9,7 @@
 protocol TransactionRepositoryProtocol {
     var delegate: ClearentWrapperProtocol? { get set }
     var offlineManager: OfflineModeManager? { get set }
-    func saleTransaction(jwt: String, saleEntity: SaleEntity, completion: @escaping (TransactionResponse?, ClearentError?) -> Void)
+    func saleTransaction(jwt: String, saleEntity: SaleEntity, isOfflineTransaction: Bool, completion: @escaping (TransactionResponse?, ClearentError?) -> Void)
     func sendSignatureRequest(image: UIImage, completion: @escaping (SignatureResponse?, ClearentError?) -> Void)
     func sendReceiptRequest(emailAddress: String, completion: @escaping (ReceiptResponse?, ClearentError?) -> Void)
     func resendSignature(completion: @escaping (SignatureResponse?, ClearentError?) -> Void)
@@ -63,7 +63,9 @@ class TransactionRepository: NSObject, TransactionRepositoryProtocol {
     
     // MARK: - Internal
     
-    func saleTransaction(jwt: String, saleEntity: SaleEntity, completion: @escaping (TransactionResponse?, ClearentError?) -> Void) {
+    func saleTransaction(jwt: String, saleEntity: SaleEntity, isOfflineTransaction: Bool, completion: @escaping (TransactionResponse?, ClearentError?) -> Void) {
+        let saleEntity = saleEntity
+        saleEntity.updateSoftwareType(isOfflineTransaction: isOfflineTransaction)
         httpClient.saleTransaction(jwt: jwt, saleEntity: saleEntity) { [weak self] data, error in
             guard let strongSelf = self else { return }
             guard let responseData = data else {
@@ -246,7 +248,7 @@ class TransactionRepository: NSObject, TransactionRepositoryProtocol {
      * Method that performs a manual card transaction.
      */
      func manualEntryTransaction(saleEntity: SaleEntity) {
-        let dispatchQueue = DispatchQueue(label: "xplor.UserInteractiveQueue", qos: .userInteractive, attributes: .concurrent)
+        let dispatchQueue = DispatchQueue(label: "xsdk.UserInteractiveQueue", qos: .userInteractive, attributes: .concurrent)
          
         dispatchQueue.async { [weak self] in
             guard let strongSelf = self else { return }
@@ -328,7 +330,7 @@ class TransactionRepository: NSObject, TransactionRepositoryProtocol {
         saleEntity.amount = saleEntity.amount.setTwoDecimals()
         saleEntity.tipAmount = saleEntity.tipAmount?.setTwoDecimals()
         
-        saleTransaction(jwt: token.jwt, saleEntity: saleEntity) { [weak self] (response, error) in
+        saleTransaction(jwt: token.jwt, saleEntity: saleEntity, isOfflineTransaction: true) { [weak self] (response, error) in
             if error != nil {
                 completion(error, response)
             } else  {

--- a/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
+++ b/ClearentIdtechIOSFramework/ClearentWrapper/Wrapper/ClearentWrapper.swift
@@ -250,7 +250,7 @@ public final class ClearentWrapper : NSObject {
      * @param completion, the closure that will be called after a sale response is received. This is dispatched onto the main queue
      */
     public func saleTransaction(jwt: String, saleEntity: SaleEntity, completion: @escaping (TransactionResponse?, ClearentError?) -> Void) {
-        transactionRepository?.saleTransaction(jwt: jwt, saleEntity: saleEntity) { (response, error) in
+        transactionRepository?.saleTransaction(jwt: jwt, saleEntity: saleEntity, isOfflineTransaction: false) { (response, error) in
             DispatchQueue.main.async {
                 completion(response, error)
             }


### PR DESCRIPTION
Software type naming for different scenarios:

>        1. Our native app is used ->  Xplor Pay Mobile_[offline]_iOS
>                                  -> add sdk version to softwareTypeVersion field
>        2. Integrator didn’t add anything -> Xplor Pay SDK_<sdk version>_ [offline]_iOS
>        3. Otherwise -> <integrator's choice>_Xplor Pay SDK_<sdk version>_[offline]_iOS
      
